### PR TITLE
[RMS-005] Slickの設定 ドメインモデルとDBのマッピング定義

### DIFF
--- a/app/domain/model/company/Employee.scala
+++ b/app/domain/model/company/Employee.scala
@@ -7,7 +7,7 @@ import cats.implicits._
 
 import domain.value.common._
 
-import library.model.EntityId
+import library.model.{Entity, EntityId}
 
 import io.estatico.newtype.macros.newtype
 
@@ -21,7 +21,7 @@ case class Employee (
   phoneNumber:   PhoneNumber,
   email:         Email,
   licenseNumber: Option[LicenseNumber]
-)
+) extends Entity[Employee.Id]
 
 object Employee extends EntityId {
 

--- a/app/domain/model/company/Employee.scala
+++ b/app/domain/model/company/Employee.scala
@@ -7,7 +7,7 @@ import cats.implicits._
 
 import domain.value.common._
 
-import library.model.EntityEmbededId
+import library.model.EntityId
 
 import io.estatico.newtype.macros.newtype
 
@@ -23,7 +23,7 @@ case class Employee (
   licenseNumber: Option[LicenseNumber]
 )
 
-object Employee extends EntityEmbededId {
+object Employee extends EntityId {
 
   @newtype case class LicenseNumber(value: Int)
 

--- a/app/domain/model/company/Employee.scala
+++ b/app/domain/model/company/Employee.scala
@@ -5,7 +5,11 @@ import java.util.UUID
 import cats.data.ValidatedNel
 import cats.implicits._
 
-import domain.value.common._
+import domain.value.common.name._
+import domain.value.common.address.Address
+import domain.value.common.age.Age
+import domain.value.common.phone.PhoneNumber
+import domain.value.common.email.Email
 
 import library.model.{Entity, EntityId}
 

--- a/app/domain/model/contract/Agreement.scala
+++ b/app/domain/model/contract/Agreement.scala
@@ -4,7 +4,7 @@ import java.util.UUID
 
 import domain.model.contract.ContractInformation
 
-import library.model.EntityId
+import library.model.{Entity, EntityId}
 
 import io.estatico.newtype.macros.newtype
 
@@ -12,7 +12,7 @@ case class Agreement (
   id:           Agreement.Id,
   infomationId: ContractInformation.Id,
   name:         Agreement.Name
-)
+) extends Entity[Agreement.Id]
 
 object Agreement extends EntityId {
 

--- a/app/domain/model/contract/Agreement.scala
+++ b/app/domain/model/contract/Agreement.scala
@@ -4,7 +4,7 @@ import java.util.UUID
 
 import domain.model.contract.ContractInformation
 
-import library.model.EntityEmbededId
+import library.model.EntityId
 
 import io.estatico.newtype.macros.newtype
 
@@ -14,7 +14,7 @@ case class Agreement (
   name:         Agreement.Name
 )
 
-object Agreement extends EntityEmbededId {
+object Agreement extends EntityId {
 
   @newtype case class Name(value: String)
 

--- a/app/domain/model/contract/ContractInformation.scala
+++ b/app/domain/model/contract/ContractInformation.scala
@@ -4,7 +4,7 @@ import java.util.UUID
 
 import domain.model.property.Property
 
-import library.model.EntityEmbededId
+import library.model.EntityId
 
 import io.estatico.newtype.macros.newtype
 
@@ -14,7 +14,7 @@ case class ContractInformation (
   contents:   ContractInformation.Contents
 )
 
-object ContractInformation extends EntityEmbededId {
+object ContractInformation extends EntityId {
 
   @newtype case class Contents(value: String)
 

--- a/app/domain/model/contract/ContractInformation.scala
+++ b/app/domain/model/contract/ContractInformation.scala
@@ -4,7 +4,7 @@ import java.util.UUID
 
 import domain.model.property.Property
 
-import library.model.EntityId
+import library.model.{Entity, EntityId}
 
 import io.estatico.newtype.macros.newtype
 
@@ -12,7 +12,7 @@ case class ContractInformation (
   id:         ContractInformation.Id,
   propertyId: Property.Id,
   contents:   ContractInformation.Contents
-)
+) extends Entity[ContractInformation.Id]
 
 object ContractInformation extends EntityId {
 

--- a/app/domain/model/contract/ContractOfBuy.scala
+++ b/app/domain/model/contract/ContractOfBuy.scala
@@ -3,9 +3,9 @@ package domain.model.contract
 import domain.model.company._
 
 case class ContractOfBuy(
-  contractInformation: ContractInformation.Id,
-  subscriberId:        Subscriber.Id,
-  employeeId:          Employee.Id
+  contractInformationId: ContractInformation.Id,
+  subscriberId:          Subscriber.Id,
+  employeeId:            Employee.Id
 )
 
 object ContractOfBuy {
@@ -16,9 +16,9 @@ object ContractOfBuy {
     rawEmployeeId:            Employee.Id
   ): ContractOfBuy = {
     ContractOfBuy(
-      contractInformation = rawContractInformationId,
-      subscriberId        = rawSubscriberId,
-      employeeId          = rawEmployeeId
+      contractInformationId = rawContractInformationId,
+      subscriberId          = rawSubscriberId,
+      employeeId            = rawEmployeeId
     )
   }
 }

--- a/app/domain/model/contract/PaymentSlip.scala
+++ b/app/domain/model/contract/PaymentSlip.scala
@@ -8,7 +8,7 @@ import cats.implicits._
 import domain.model.contract.ContractInformation
 import domain.value.property._
 
-import library.model.EntityEmbededId
+import library.model.EntityId
 
 import io.estatico.newtype.macros.newtype
 
@@ -19,7 +19,7 @@ case class PaymentSlip (
   price:         Price
 )
 
-object PaymentSlip extends EntityEmbededId {
+object PaymentSlip extends EntityId {
 
   @newtype case class ItemName(value: String)
 

--- a/app/domain/model/contract/PaymentSlip.scala
+++ b/app/domain/model/contract/PaymentSlip.scala
@@ -7,6 +7,7 @@ import cats.implicits._
 
 import domain.model.contract.ContractInformation
 import domain.value.property._
+import domain.value.property.price.Price
 
 import library.model.{Entity, EntityId}
 

--- a/app/domain/model/contract/PaymentSlip.scala
+++ b/app/domain/model/contract/PaymentSlip.scala
@@ -8,7 +8,7 @@ import cats.implicits._
 import domain.model.contract.ContractInformation
 import domain.value.property._
 
-import library.model.EntityId
+import library.model.{Entity, EntityId}
 
 import io.estatico.newtype.macros.newtype
 
@@ -17,7 +17,7 @@ case class PaymentSlip (
   informationId: ContractInformation.Id,
   itemName:      PaymentSlip.ItemName,
   price:         Price
-)
+) extends Entity[PaymentSlip.Id]
 
 object PaymentSlip extends EntityId {
 

--- a/app/domain/model/contract/Subscriber.scala
+++ b/app/domain/model/contract/Subscriber.scala
@@ -5,7 +5,12 @@ import java.util.UUID
 import cats.data.ValidatedNel
 import cats.implicits._
 
-import domain.value.common._
+import domain.value.common.age.Age
+import domain.value.common.phone.PhoneNumber
+import domain.value.common.name._
+import domain.value.common.email.Email
+import domain.value.common.address.Address
+
 import library.model.{Entity, EntityId}
 
 case class Subscriber(

--- a/app/domain/model/contract/Subscriber.scala
+++ b/app/domain/model/contract/Subscriber.scala
@@ -6,7 +6,7 @@ import cats.data.ValidatedNel
 import cats.implicits._
 
 import domain.value.common._
-import library.model.EntityId
+import library.model.{Entity, EntityId}
 
 case class Subscriber(
   id:           Subscriber.Id,
@@ -16,7 +16,7 @@ case class Subscriber(
   address:      Address,
   phoneNumber:  PhoneNumber,
   email:        Email
-)
+) extends Entity[Subscriber.Id]
 
 object Subscriber extends EntityId {
 

--- a/app/domain/model/contract/Subscriber.scala
+++ b/app/domain/model/contract/Subscriber.scala
@@ -6,7 +6,7 @@ import cats.data.ValidatedNel
 import cats.implicits._
 
 import domain.value.common._
-import library.model.EntityEmbededId
+import library.model.EntityId
 
 case class Subscriber(
   id:           Subscriber.Id,
@@ -18,7 +18,7 @@ case class Subscriber(
   email:        Email
 )
 
-object Subscriber extends EntityEmbededId {
+object Subscriber extends EntityId {
 
   def create(
     rawFirstName:   String,

--- a/app/domain/model/property/Property.scala
+++ b/app/domain/model/property/Property.scala
@@ -8,7 +8,7 @@ import cats.implicits._
 import domain.value.property._
 import domain.value.common._
 
-import library.model.EntityEmbededId
+import library.model.EntityId
 
 case class Property(
   id:                 Property.Id,
@@ -20,7 +20,7 @@ case class Property(
   arrangementOfRooms: ArrangementOfRooms
 )
 
-object Property extends EntityEmbededId {
+object Property extends EntityId {
 
   def create(
     rawAddress:            String,

--- a/app/domain/model/property/Property.scala
+++ b/app/domain/model/property/Property.scala
@@ -8,7 +8,7 @@ import cats.implicits._
 import domain.value.property._
 import domain.value.common._
 
-import library.model.EntityId
+import library.model.{Entity, EntityId}
 
 case class Property(
   id:                 Property.Id,
@@ -18,7 +18,7 @@ case class Property(
   age:                Age,
   structure:          Structure,
   arrangementOfRooms: ArrangementOfRooms
-)
+) extends Entity[Property.Id]
 
 object Property extends EntityId {
 

--- a/app/domain/model/property/Property.scala
+++ b/app/domain/model/property/Property.scala
@@ -5,8 +5,12 @@ import java.util.UUID
 import cats.data.ValidatedNel
 import cats.implicits._
 
+import domain.value.common.age.Age
+import domain.value.common.address.Address
+
 import domain.value.property._
-import domain.value.common._
+import domain.value.property.price.Price
+import domain.value.property.arrangementofrooms.ArrangementOfRooms
 
 import library.model.{Entity, EntityId}
 

--- a/app/domain/value/common/Address.scala
+++ b/app/domain/value/common/Address.scala
@@ -1,16 +1,25 @@
 package domain.value.common
 
-import library.model.{EntityValue, Error}
 
-case class Address(value: String) extends EntityValue[String]
+import eu.timepit.refined._
+import eu.timepit.refined.collection._
+import eu.timepit.refined.api.Refined
 
-object Address extends Error {
+import io.estatico.newtype.macros.newtype
 
-  def apply(rawAddress: String): Either[String, Address] = {
-    Either.cond(
-      rawAddress.nonEmpty,
-      new Address(rawAddress),
-      validationError[String](rawAddress)
-    )
+
+package object address {
+
+  type AddressRule   = collection.Empty
+  type AddressString = String Refined AddressRule
+
+  @newtype case class Address(value: AddressString) {
+    def v = value.value
+  }
+
+  object Address {
+    def apply(rawAddress: String): Either[String, Address] = {
+      refineV[AddressRule](rawAddress).map(Address(_))
+    }
   }
 }

--- a/app/domain/value/common/Age.scala
+++ b/app/domain/value/common/Age.scala
@@ -4,12 +4,10 @@ import eu.timepit.refined._
 import eu.timepit.refined.numeric._
 import eu.timepit.refined.api.Refined
 
-//import io.estatico.newtype.macros.newtype
-import io.estatico.newtype.NewType
+import io.estatico.newtype.macros.newtype
 
 import library.model.{EntityValue, Error}
 
-/*
 package object age {
 
   type AgeRule = Interval.OpenClosed[0, 150]
@@ -23,61 +21,5 @@ package object age {
     def apply(rawAge: Int): Either[String, Age] = {
       refineV[AgeRule](rawAge).map(Age(_))
     }
-
   }
-}
-*/
-package object age {
-
-  type AgeRule = Interval.OpenClosed[0, 150]
-  type AgeInt  = Int Refined AgeRule
-
-  case class Age(value: AgeInt) extends EntityValue[AgeInt] {
-    def v = value.value
-  }
-
-  object Age {
-    def apply(rawAge: Int): Either[String, Age] = {
-      refineV[AgeRule](rawAge).map(Age(_))
-    }
-
-  }
-}
-
-import eu.timepit.refined.collection._
-import io.estatico.newtype.macros.newtype
-import io.estatico.newtype.ops._
-
-package object test {
-  type IdType = String Refined NonEmpty
-  type PasswordType = String Refined NonEmpty
-
-  type Name = Name.Type
-  //case class Name(value: String)
-  /*
-  object Name extends NewType.Of[String] {
-    def apply(value: String) = wrap(value)
-
-    implicit final class Ops(val self: Type) extends AnyVal {
-      def value: String = self.coerce[String]
-    }
-  }
-  */
-  object Name extends RefinedValue[String]
-
-  /*
-  @newtype case class Id(value: String)
-  @newtype case class Password(value: String)
-  */
-  case class Id(value: String) extends NewType.Default[String]
-  case class Password(value: String) extends NewType.Default[String]
-  case class LoginInfo(id: Id, password: Password, name: Name)
-
-  val validId   = Id("my1d123")
-  val password  = Password("Passw0rd!")
-  val name      = Name("hogehoge")
-  val h         = Name.unwrap
-  val string    = name.coerce[String]
-  val loginInfo = LoginInfo(id = validId, password = password, name = name)
-  //val loginInfo2 = LoginInfo(id = validId, password = name, name = name)
 }

--- a/app/domain/value/common/Age.scala
+++ b/app/domain/value/common/Age.scala
@@ -4,10 +4,12 @@ import eu.timepit.refined._
 import eu.timepit.refined.numeric._
 import eu.timepit.refined.api.Refined
 
-import io.estatico.newtype.macros.newtype
+//import io.estatico.newtype.macros.newtype
+import io.estatico.newtype.NewType
 
 import library.model.{EntityValue, Error}
 
+/*
 package object age {
 
   type AgeRule = Interval.OpenClosed[0, 150]
@@ -23,4 +25,59 @@ package object age {
     }
 
   }
+}
+*/
+package object age {
+
+  type AgeRule = Interval.OpenClosed[0, 150]
+  type AgeInt  = Int Refined AgeRule
+
+  case class Age(value: AgeInt) extends EntityValue[AgeInt] {
+    def v = value.value
+  }
+
+  object Age {
+    def apply(rawAge: Int): Either[String, Age] = {
+      refineV[AgeRule](rawAge).map(Age(_))
+    }
+
+  }
+}
+
+import eu.timepit.refined.collection._
+import io.estatico.newtype.macros.newtype
+import io.estatico.newtype.ops._
+
+package object test {
+  type IdType = String Refined NonEmpty
+  type PasswordType = String Refined NonEmpty
+
+  type Name = Name.Type
+  //case class Name(value: String)
+  /*
+  object Name extends NewType.Of[String] {
+    def apply(value: String) = wrap(value)
+
+    implicit final class Ops(val self: Type) extends AnyVal {
+      def value: String = self.coerce[String]
+    }
+  }
+  */
+  object Name extends RefinedValue[String]
+
+  /*
+  @newtype case class Id(value: String)
+  @newtype case class Password(value: String)
+  */
+  case class Id(value: String) extends NewType.Default[String]
+  case class Password(value: String) extends NewType.Default[String]
+  case class LoginInfo(id: Id, password: Password, name: Name)
+
+  val validId   = Id("my1d123")
+  val password  = Password("Passw0rd!")
+  val name      = Name("hogehoge")
+  val h         = Name.unwrap
+  val string    = name.coerce[String]
+  val loginInfo = LoginInfo(id = validId, password = password, name = name)
+  //val loginInfo2 = LoginInfo(id = validId, password = name, name = name)
 }

--- a/app/domain/value/common/Age.scala
+++ b/app/domain/value/common/Age.scala
@@ -1,37 +1,26 @@
 package domain.value.common
 
-/*
 import eu.timepit.refined._
 import eu.timepit.refined.numeric._
 import eu.timepit.refined.api.Refined
 
 import io.estatico.newtype.macros.newtype
 
+import library.model.{EntityValue, Error}
+
 package object age {
 
   type AgeRule = Interval.OpenClosed[0, 150]
   type AgeInt  = Int Refined AgeRule
 
-  @newtype case class Age(value: AgeInt)
+  @newtype case class Age(value: AgeInt) {
+    def v = value.value
+  }
 
   object Age {
     def apply(rawAge: Int): Either[String, Age] = {
       refineV[AgeRule](rawAge).map(Age(_))
     }
-  }
-}
-*/
-import library.model.{EntityValue, Error}
 
-case class Age(value: Int) extends EntityValue[Int]
-
-object Age extends Error {
-
-  def apply(rawAge: Int): Either[String, Age] = {
-    Either.cond(
-      rawAge >= 1 && rawAge <= 150,
-      new Age(rawAge),
-      validationError[Int](rawAge)
-    )
   }
 }

--- a/app/domain/value/common/Email.scala
+++ b/app/domain/value/common/Email.scala
@@ -1,6 +1,5 @@
 package domain.value.common
 
-/*
 import eu.timepit.refined._
 import eu.timepit.refined.string._
 import eu.timepit.refined.api.Refined
@@ -12,27 +11,13 @@ package object email {
   type EmailRule   = MatchesRegex["""[\w\-._]+@[\w\-._]+\.[A-Za-z]+"""]
   type EmailString = String Refined EmailRule
 
-  @newtype case class Email(value: EmailString)
+  @newtype case class Email(value: EmailString) {
+    def v = value.value
+  }
 
   object Email {
     def apply(rawEmail: String): Either[String, Email] = {
       refineV[EmailRule](rawEmail).map(Email(_))
     }
-  }
-}
-*/
-
-import library.model.{EntityValue, Error}
-
-case class Email(value: String) extends EntityValue[String]
-
-object Email extends Error {
-
-  def apply(rawEmail: String): Either[String, Email] = {
-    Either.cond(
-      rawEmail.matches("""[\w\-._]+@[\w\-._]+\.[A-Za-z]+"""),
-      new Email(rawEmail),
-      validationError[String](rawEmail)
-    )
   }
 }

--- a/app/domain/value/common/Name.scala
+++ b/app/domain/value/common/Name.scala
@@ -1,5 +1,4 @@
 package domain.value.common
-/*
 import eu.timepit.refined._
 import eu.timepit.refined.collection._
 import eu.timepit.refined.boolean._
@@ -13,43 +12,21 @@ package object name {
   type NameRule   = MinSize[1] And MaxSize[16]
   type NameString = String Refined NameRule
 
-  @newtype case class FirstName(value: NameString)
+  @newtype case class FirstName(value: NameString) {
+    def v = value.value
+  }
   object FirstName {
     def apply(rawFirstName: String): Either[String, FirstName] = {
       refineV[NameRule](rawFirstName).map(FirstName(_))
     }
   }
 
-  @newtype case class LastName(value: NameString)
+  @newtype case class LastName(value: NameString) {
+    def v = value.value
+  }
   object LastName {
     def apply(rawLastName: String): Either[String, LastName] = {
       refineV[NameRule](rawLastName).map(LastName(_))
     }
-  }
-}
-*/
-import library.model.{EntityValue, Error}
-
-case class FirstName(value: String) extends EntityValue[String]
-object FirstName extends Error {
-
-  def apply(rawFirstName: String): Either[String, FirstName] = {
-    Either.cond(
-      rawFirstName.nonEmpty,
-      new FirstName(rawFirstName),
-      validationError[String](rawFirstName)
-    )
-  }
-}
-
-case class LastName(value: String) extends EntityValue[String]
-object LastName extends Error {
-
-  def apply(rawLastName: String): Either[String, LastName] = {
-    Either.cond(
-      rawLastName.nonEmpty,
-      new LastName(rawLastName),
-      validationError[String](rawLastName)
-    )
   }
 }

--- a/app/domain/value/common/PhoneNumber.scala
+++ b/app/domain/value/common/PhoneNumber.scala
@@ -1,5 +1,4 @@
 package domain.value.common
-/*
 import eu.timepit.refined._
 import eu.timepit.refined.collection._
 import eu.timepit.refined.string._
@@ -12,26 +11,13 @@ package object phone {
   type PhoneNumberRule = MatchesRegex[W.`"[0-9]+"`.T]
   type PhoneNumberInt  = String Refined PhoneNumberRule
 
-  @newtype case class PhoneNumber(value: PhoneNumberInt)
+  @newtype case class PhoneNumber(value: PhoneNumberInt) {
+    def v = value.value
+  }
 
   object PhoneNumber {
     def apply(rawPhoneNumber: String): Either[String, PhoneNumber] = {
       refineV[PhoneNumberRule](rawPhoneNumber).map(PhoneNumber(_))
     }
-  }
-}
-*/
-import library.model.{EntityValue, Error}
-
-case class PhoneNumber(value: String) extends EntityValue[String]
-
-object PhoneNumber extends Error {
-
-  def apply(rawPhoneNumber: String): Either[String, PhoneNumber] = {
-    Either.cond(
-      rawPhoneNumber.matches("^\\d{2,4}-\\d{2,4}-\\d{4}$"),
-      new PhoneNumber(rawPhoneNumber),
-      validationError[String](rawPhoneNumber)
-    )
   }
 }

--- a/app/domain/value/property/ArrangementOfRooms.scala
+++ b/app/domain/value/property/ArrangementOfRooms.scala
@@ -1,5 +1,4 @@
 package domain.value.property
-/*
 import eu.timepit.refined._
 import eu.timepit.refined.collection._
 import eu.timepit.refined.string._
@@ -12,7 +11,9 @@ package object arrangementofrooms {
   type ArrangementOfRoomsRule   = MatchesRegex["""[1-9]+[A-Z]+[A-Z]"""]
   type ArrangementOfRoomsString = String Refined ArrangementOfRoomsRule
 
-  @newtype case class ArrangementOfRooms(value: ArrangementOfRoomsString)
+  @newtype case class ArrangementOfRooms(value: ArrangementOfRoomsString) {
+    def v = value.value
+  }
 
   object ArrangementOfRooms {
     def apply(rawArrangementOfRooms: String): Either[String, ArrangementOfRooms] = {
@@ -20,19 +21,4 @@ package object arrangementofrooms {
     }
   }
 
-}
-*/
-import library.model.{EntityValue, Error}
-
-case class ArrangementOfRooms(value: String) extends EntityValue[String]
-
-object ArrangementOfRooms extends Error {
-
-  def apply(rawArrangementOfRooms: String): Either[String, ArrangementOfRooms] = {
-    Either.cond(
-      rawArrangementOfRooms.matches("""[1-9]+[A-Z]+[A-Z]"""),
-      new ArrangementOfRooms(rawArrangementOfRooms),
-      validationError[String](rawArrangementOfRooms)
-    )
-  }
 }

--- a/app/domain/value/property/Price.scala
+++ b/app/domain/value/property/Price.scala
@@ -1,5 +1,4 @@
 package domain.value.property
-/*
 import eu.timepit.refined._
 import eu.timepit.refined.collection._
 import eu.timepit.refined.string._
@@ -12,26 +11,13 @@ package object price {
   type PriceRule   = MatchesRegex["""\b\d{1,3}(,\d{3})*\b"""]
   type PriceString = String Refined PriceRule
 
-  @newtype case class Price(value: PriceString)
+  @newtype case class Price(value: PriceString) {
+    def v = value.value
+  }
 
   object Price {
     def apply(rawPrice: String): Either[String, Price] = {
       refineV[PriceRule](rawPrice).map(Price(_))
     }
-  }
-}
-*/
-import library.model.{EntityValue, Error}
-
-case class Price(value: String) extends EntityValue[String]
-
-object Price extends Error {
-
-  def apply(rawPrice: String): Either[String, Price] = {
-    Either.cond(
-      rawPrice.matches("""\b\d{1,3}(,\d{3})*\b"""),
-      new Price(rawPrice),
-      validationError[String](rawPrice)
-    )
   }
 }

--- a/app/interface-adapter/gateway/dao/company/Employee.scala
+++ b/app/interface-adapter/gateway/dao/company/Employee.scala
@@ -1,0 +1,44 @@
+package gateway.dao
+
+import slick.lifted.Tag
+
+import library.backend.SlickTable
+import library.backend.SlickDatabaseConfig
+
+import domain.model.company._
+import domain.model.company.Employee._
+import domain.value.common.name._
+import domain.value.common.address._
+import domain.value.common.age._
+import domain.value.common.phone._
+import domain.value.common.email._
+
+class EmployeeTable(tag: Tag) extends SlickTable[Employee](tag, "employee") {
+
+  import api._
+  import mapping._
+
+  /* @1 */ def id            = column[Employee.Id]          ("employee_id", O.PrimaryKey)
+  /* @2 */ def firstName     = column[NameString]           ("first_name")
+  /* @3 */ def lastName      = column[NameString]           ("last_name")
+  /* @4 */ def age           = column[AgeInt]               ("age")
+  /* @5 */ def address       = column[AddressString]        ("address")
+  /* @6 */ def phoneNumber   = column[PhoneNumberInt]       ("phone_number")
+  /* @7 */ def email         = column[EmailString]          ("email")
+  /* @8 */ def licenseNumber = column[LicenseNumberString]  ("license_number")
+
+  type TableElementTuple = (
+    Employee.Id,   NameString,     NameString,  AgeInt,
+    AddressString, PhoneNumberInt, EmailString, Option[LicenseNumberString]
+  )
+
+  def * = (id, firstName, lastName, age, address, phoneNumber, email, licenseNumber.?) .<> (
+    (x: TableElementTuple) => Employee(
+      x._1,          FirstName(x._2),   LastName(x._3), Age(x._4),
+      Address(x._5), PhoneNumber(x._6), Email(x._7),    x._8.map(LicenseNumber(_))
+    ),
+    (v: Employee) => Employee.unapply(v).map {t => (
+      t._1, t._2.value, t._3.value, t._4.value, t._5.value, t._6.value, t._7.value, t._8.map(_.value)
+    )}
+  )
+}

--- a/app/interface-adapter/gateway/dao/contract/Agreement.scala
+++ b/app/interface-adapter/gateway/dao/contract/Agreement.scala
@@ -1,0 +1,32 @@
+package gateway.dao
+
+import slick.lifted.Tag
+
+import library.backend.SlickTable
+import library.backend.SlickDatabaseConfig
+
+import domain.model.contract.{Agreement, ContractInformation}
+
+import Agreement.Name
+class AgreementTable(tag: Tag) extends SlickTable[Agreement](tag, "agreement") {
+
+  import api._
+  import mapping._
+
+  /* @1 */ def id                    = column[Agreement.Id]            ("agreement_id", O.PrimaryKey)
+  /* @2 */ def contractInformationId = column[ContractInformation.Id]  ("contract_information_id")
+  /* @3 */ def name                  = column[String]                  ("name")
+
+  type TableElementTuple = (
+    Agreement.Id, ContractInformation.Id, String,
+  )
+
+  def * = (id, contractInformationId, name) .<> (
+    (x: TableElementTuple) => Agreement(
+      x._1, x._2, Name(x._3)
+    ),
+    (v: Agreement) => Agreement.unapply(v).map {t => (
+      t._1, t._2, t._3.value
+    )}
+  )
+}

--- a/app/interface-adapter/gateway/dao/contract/ContractInformation.scala
+++ b/app/interface-adapter/gateway/dao/contract/ContractInformation.scala
@@ -1,0 +1,34 @@
+package gateway.dao
+
+import slick.lifted.Tag
+
+import library.backend.SlickTable
+import library.backend.SlickDatabaseConfig
+
+import domain.model.company.Employee
+import domain.model.property.Property
+import domain.model.contract._
+
+import ContractInformation._
+class ContractInformationTable(tag: Tag) extends SlickTable[ContractInformation](tag, "contract_information") {
+
+  import api._
+  import mapping._
+
+  /* @1 */ def id         = column[ContractInformation.Id]  ("id", O.PrimaryKey)
+  /* @2 */ def propertyId = column[Property.Id]             ("property_id")
+  /* @3 */ def contents   = column[String]                  ("contents")
+
+  type TableElementTuple = (
+    ContractInformation.Id, Property.Id, String
+  )
+
+  def * = (id, propertyId, contents) .<> (
+    (x: TableElementTuple) => ContractInformation(
+      x._1, x._2, Contents(x._3)
+    ),
+    (v: ContractInformation) => ContractInformation.unapply(v).map {t => (
+      t._1, t._2, t._3.value
+    )}
+  )
+}

--- a/app/interface-adapter/gateway/dao/contract/ContractOfBuy.scala
+++ b/app/interface-adapter/gateway/dao/contract/ContractOfBuy.scala
@@ -1,0 +1,32 @@
+package gateway.dao
+
+import slick.lifted.Tag
+
+import library.backend.SlickTable
+import library.backend.SlickDatabaseConfig
+
+import domain.model.company.Employee
+import domain.model.contract.{ContractOfBuy, ContractInformation, Subscriber}
+
+class ContractOfBuyTable(tag: Tag) extends SlickTable[ContractOfBuy](tag, "contract_of_buy") {
+
+  import api._
+  import mapping._
+
+  /* @1 */ def contractInformationId = column[ContractInformation.Id]  ("contract_information_id", O.PrimaryKey)
+  /* @2 */ def subscriberId          = column[Subscriber.Id]           ("subscriber_id")
+  /* @3 */ def employeeId            = column[Employee.Id]             ("employee_id")
+
+  type TableElementTuple = (
+    ContractInformation.Id, Subscriber.Id, Employee.Id,
+  )
+
+  def * = (contractInformationId, subscriberId, employeeId) .<> (
+    (x: TableElementTuple) => ContractOfBuy(
+      x._1, x._2, x._3
+    ),
+    (v: ContractOfBuy) => ContractOfBuy.unapply(v).map {t => (
+      t._1, t._2, t._3
+    )}
+  )
+}

--- a/app/interface-adapter/gateway/dao/contract/ContractOfSale.scala
+++ b/app/interface-adapter/gateway/dao/contract/ContractOfSale.scala
@@ -1,0 +1,32 @@
+package gateway.dao
+
+import slick.lifted.Tag
+
+import library.backend.SlickTable
+import library.backend.SlickDatabaseConfig
+
+import domain.model.company.Employee
+import domain.model.contract.{ContractOfSale, ContractInformation, Subscriber}
+
+class ContractOfSaleTable(tag: Tag) extends SlickTable[ContractOfSale](tag, "contract_of_sale") {
+
+  import api._
+  import mapping._
+
+  /* @1 */ def contractInformationId = column[ContractInformation.Id]  ("contract_information_id", O.PrimaryKey)
+  /* @2 */ def subscriberId          = column[Subscriber.Id]           ("subscriber_id")
+  /* @3 */ def employeeId            = column[Employee.Id]             ("employee_id")
+
+  type TableElementTuple = (
+    ContractInformation.Id, Subscriber.Id, Employee.Id,
+  )
+
+  def * = (contractInformationId, subscriberId, employeeId) .<> (
+    (x: TableElementTuple) => ContractOfSale(
+      x._1, x._2, x._3
+    ),
+    (v: ContractOfSale) => ContractOfSale.unapply(v).map {t => (
+      t._1, t._2, t._3
+    )}
+  )
+}

--- a/app/interface-adapter/gateway/dao/contract/PaymentSlip.scala
+++ b/app/interface-adapter/gateway/dao/contract/PaymentSlip.scala
@@ -1,0 +1,36 @@
+package gateway.dao
+
+import slick.lifted.Tag
+
+import library.backend.SlickTable
+import library.backend.SlickDatabaseConfig
+
+import domain.model.contract.PaymentSlip
+import domain.model.contract.ContractInformation
+import domain.value.property._
+import domain.value.property.price._
+
+import PaymentSlip._
+class PaymentSlipTable(tag: Tag) extends SlickTable[PaymentSlip](tag, "payment_slip") {
+
+  import api._
+  import mapping._
+
+  /* @1 */ def id             = column[PaymentSlip.Id]          ("id", O.PrimaryKey)
+  /* @2 */ def informationId  = column[ContractInformation.Id]  ("contract_information_id")
+  /* @3 */ def itemName       = column[String]                  ("item_name")
+  /* @4 */ def price          = column[PriceString]             ("price")
+
+  type TableElementTuple = (
+    PaymentSlip.Id, ContractInformation.Id, String, PriceString
+  )
+
+  def * = (id, informationId, itemName, price) .<> (
+    (x: TableElementTuple) => PaymentSlip(
+      x._1, x._2, ItemName(x._3), Price(x._4)
+    ),
+    (v: PaymentSlip) => PaymentSlip.unapply(v).map {t => (
+      t._1, t._2, t._3.value, t._4.value
+    )}
+  )
+}

--- a/app/interface-adapter/gateway/dao/contract/Subscriber.scala
+++ b/app/interface-adapter/gateway/dao/contract/Subscriber.scala
@@ -1,0 +1,42 @@
+package gateway.dao
+
+import slick.lifted.Tag
+
+import library.backend.SlickTable
+import library.backend.SlickDatabaseConfig
+
+import domain.model.contract.Subscriber
+
+import domain.value.common.age._
+import domain.value.common.phone._
+import domain.value.common.name._
+import domain.value.common.email._
+import domain.value.common.address._
+
+class SubscriberTable(tag: Tag) extends SlickTable[Subscriber](tag, "subscriber") {
+
+  import api._
+  import mapping._
+
+  /* @1 */ def id           = column[Subscriber.Id]     ("subscriber_id", O.PrimaryKey)
+  /* @2 */ def firstName    = column[NameString]        ("first_name")
+  /* @3 */ def lastName     = column[NameString]        ("last_name")
+  /* @4 */ def age          = column[AgeInt]            ("age")
+  /* @5 */ def address      = column[AddressString]     ("address")
+  /* @6 */ def phoneNumber  = column[PhoneNumberInt]    ("phone_number")
+  /* @7 */ def email        = column[EmailString]       ("email")
+
+  type TableElementTuple = (
+    Subscriber.Id, NameString,     NameString, AgeInt,
+    AddressString, PhoneNumberInt, EmailString
+  )
+
+  def * = (id, firstName, lastName, age, address, phoneNumber, email) .<> (
+    (x: TableElementTuple) => Subscriber(
+      x._1, FirstName(x._2), LastName(x._3), Age(x._4), Address(x._5), PhoneNumber(x._6), Email(x._7)
+    ),
+    (v: Subscriber) => Subscriber.unapply(v).map {t => (
+      t._1, t._2.value, t._3.value, t._4.value, t._5.value, t._6.value, t._7.value
+    )}
+  )
+}

--- a/app/interface-adapter/gateway/dao/property/Property.scala
+++ b/app/interface-adapter/gateway/dao/property/Property.scala
@@ -1,0 +1,43 @@
+package gateway.dao
+
+import slick.lifted.Tag
+
+import library.backend.SlickTable
+import library.backend.SlickDatabaseConfig
+
+import domain.model.property.Property
+
+import domain.value.common.age._
+import domain.value.common.address._
+
+import domain.value.property._
+import domain.value.property.price._
+import domain.value.property.arrangementofrooms._
+
+class PropertyTable(tag: Tag) extends SlickTable[Property](tag, "property") {
+
+  import api._
+  import mapping._
+
+  /* @1 */ def id                 = column[Property.Id]                ("property_id", O.PrimaryKey)
+  /* @2 */ def address            = column[AddressString]              ("address")
+  /* @3 */ def types              = column[Int]                        ("types")
+  /* @4 */ def price              = column[PriceString]                ("price")
+  /* @5 */ def age                = column[AgeInt]                     ("age")
+  /* @6 */ def structure          = column[Int]                        ("structure")
+  /* @7 */ def arrangementOfRooms = column[ArrangementOfRoomsString]   ("arrangement_of_rooms")
+
+  type TableElementTuple = (
+    Property.Id, AddressString, Int,  PriceString,
+    AgeInt, Int, ArrangementOfRoomsString
+  )
+
+  def * = (id, address, types, price, age, structure, arrangementOfRooms) .<> (
+    (x: TableElementTuple) => Property(
+      x._1, Address(x._2), Type.find(x._3), Price(x._4), Age(x._5), Structure.find(x._6), ArrangementOfRooms(x._7)
+    ),
+    (v: Property) => Property.unapply(v).map {t => (
+      t._1, t._2.value, t._3.code, t._4.value, t._5.value, t._6.code, t._7.value
+    )}
+  )
+}

--- a/app/library/src/main/scala/backend/RefinedColumnType.scala
+++ b/app/library/src/main/scala/backend/RefinedColumnType.scala
@@ -1,0 +1,21 @@
+package library.backend
+
+import scala.reflect.ClassTag
+
+import library.model.EntityValue
+
+import java.util.UUID
+
+trait RefinedColumnType extends SlickDatabaseConfig {
+  import api._
+
+  implicit def ValueIntType[T <: EntityValue[UUID]](implicit tag: ClassTag[T]) = {
+    MappedColumnType.base[T, String](
+      v   => v.value.toString,
+      str => tag.runtimeClass
+       .getConstructor(classOf[UUID])
+       .newInstance(UUID.fromString(str))
+       .asInstanceOf[T]
+    )
+  }
+}

--- a/app/library/src/main/scala/backend/RefinedProfile.scala
+++ b/app/library/src/main/scala/backend/RefinedProfile.scala
@@ -1,0 +1,12 @@
+package library.backend
+
+import slick.jdbc.JdbcProfile
+
+import be.venneborg.refined.RefinedMapping
+import be.venneborg.refined.RefinedSupport
+
+trait RefinedProfile extends JdbcProfile
+  with RefinedMapping
+  with RefinedSupport
+
+object RefinedProfile extends RefinedProfile

--- a/app/library/src/main/scala/backend/SlickColumnType.scala
+++ b/app/library/src/main/scala/backend/SlickColumnType.scala
@@ -6,10 +6,10 @@ import library.model.EntityValue
 
 import java.util.UUID
 
-trait RefinedColumnType extends SlickDatabaseConfig {
+trait SlickColumnType extends SlickDatabaseConfig {
   import api._
 
-  implicit def ValueIntType[T <: EntityValue[UUID]](implicit tag: ClassTag[T]) = {
+  implicit def ValueUUIDType[T <: EntityValue[UUID]](implicit tag: ClassTag[T]) = {
     MappedColumnType.base[T, String](
       v   => v.value.toString,
       str => tag.runtimeClass
@@ -18,4 +18,5 @@ trait RefinedColumnType extends SlickDatabaseConfig {
        .asInstanceOf[T]
     )
   }
+
 }

--- a/app/library/src/main/scala/backend/SlickDatabaseConfig.scala
+++ b/app/library/src/main/scala/backend/SlickDatabaseConfig.scala
@@ -1,0 +1,15 @@
+package library.backend
+
+import slick.jdbc.JdbcProfile
+import slick.basic.DatabaseConfig
+
+trait SlickDatabaseConfig extends RefinedProfile {
+
+  override val api = new API with RefinedImplicits
+
+  import api._
+
+  val db: JdbcProfile#Backend#Database = Database.forConfig("database")
+}
+
+object SlickDatabaseConfig extends SlickDatabaseConfig

--- a/app/library/src/main/scala/backend/SlickTable.scala
+++ b/app/library/src/main/scala/backend/SlickTable.scala
@@ -8,4 +8,4 @@ abstract class SlickTable[M](
   tag:       Tag,
   tableName: String
 ) extends Table[M](tag, tableName)
-  with    RefinedColumnType
+  with    SlickColumnType

--- a/app/library/src/main/scala/backend/SlickTable.scala
+++ b/app/library/src/main/scala/backend/SlickTable.scala
@@ -1,0 +1,11 @@
+package library.backend
+
+import slick.lifted.Tag
+
+import SlickDatabaseConfig.profile._
+
+abstract class SlickTable[M](
+  tag:       Tag,
+  tableName: String
+) extends Table[M](tag, tableName)
+  with    RefinedColumnType

--- a/app/library/src/main/scala/model/Entity.scala
+++ b/app/library/src/main/scala/model/Entity.scala
@@ -1,0 +1,7 @@
+package library.model
+
+trait Entity[M] {
+
+  val id: M
+
+}

--- a/app/library/src/main/scala/model/EntityId.scala
+++ b/app/library/src/main/scala/model/EntityId.scala
@@ -2,7 +2,7 @@ package library.model
 
 import java.util.UUID
 
-trait EntityEmbededId {
+trait EntityId {
 
   case class Id(value: UUID)
 

--- a/app/library/src/main/scala/model/EntityId.scala
+++ b/app/library/src/main/scala/model/EntityId.scala
@@ -4,6 +4,6 @@ import java.util.UUID
 
 trait EntityId {
 
-  case class Id(value: UUID)
+  case class Id(value: UUID) extends EntityValue[UUID]
 
 }

--- a/build.sbt
+++ b/build.sbt
@@ -9,10 +9,12 @@ scalaVersion := "2.13.3"
 
 libraryDependencies ++= Seq(
   guice,
-  "org.scalatestplus.play" %% "scalatestplus-play" % "5.0.0" % Test,
-  "org.typelevel"          %% "cats-core"          % "2.0.0",
-  "eu.timepit"             %% "refined"            % "0.9.13",
-  "io.estatico"            %% "newtype"            % "0.4.4"
+  "org.scalatestplus.play" %% "scalatestplus-play"   % "5.0.0" % Test,
+  "org.typelevel"          %% "cats-core"            % "2.0.0",
+  "eu.timepit"             %% "refined"              % "0.9.13",
+  "io.estatico"            %% "newtype"              % "0.4.4",
+  "mysql"                  %  "mysql-connector-java" % "8.0.12",
+  "com.typesafe.play"      %% "play-slick"           % "5.0.0"
 )
 
 addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.11.0" cross CrossVersion.full)

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,5 @@
-name := """real-estate-sales-contract-management-system"""
+name         := """real-estate-sales-contract-management-system"""
 organization := "com.example"
-
-//version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
@@ -12,6 +10,7 @@ libraryDependencies ++= Seq(
   "org.scalatestplus.play" %% "scalatestplus-play"   % "5.0.0" % Test,
   "org.typelevel"          %% "cats-core"            % "2.0.0",
   "eu.timepit"             %% "refined"              % "0.9.13",
+  "be.venneborg"           %% "slick-refined"        % "0.5.0",
   "io.estatico"            %% "newtype"              % "0.4.4",
   "mysql"                  %  "mysql-connector-java" % "8.0.12",
   "com.typesafe.play"      %% "play-slick"           % "5.0.0"

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,16 +1,4 @@
 # https://www.playframework.com/documentation/latest/Configuration
-#
-#db_connection {
-#  mysql {
-#    dataSourceClass = "slick.jdbc.DatabaseUrlDataSource"
-#    properties = {
-#      url      = "jdbc:mysql://localhost/contract_management_system",
-#      driver   = "com.mysql.jdbc.Driver",
-#      user     = "root",
-#      password = "transamGN001"
-#    }
-#  }
-#}
 
 database {
   profile = "slick.jdbc.MySQLProfile$"

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,1 +1,26 @@
 # https://www.playframework.com/documentation/latest/Configuration
+#
+#db_connection {
+#  mysql {
+#    dataSourceClass = "slick.jdbc.DatabaseUrlDataSource"
+#    properties = {
+#      url      = "jdbc:mysql://localhost/contract_management_system",
+#      driver   = "com.mysql.jdbc.Driver",
+#      user     = "root",
+#      password = "transamGN001"
+#    }
+#  }
+#}
+
+database {
+  profile = "slick.jdbc.MySQLProfile$"
+  db {
+    dataSourceClass = "slick.jdbc.DatabaseUrlDataSource"
+    properties {
+      driver   = "com.mysql.jdbc.Driver"
+      user     = "root"
+      url      = "jdbc:mysql://localhost/contract_management_system"
+      password = "transamGN001"
+    }
+  }
+}


### PR DESCRIPTION
# Pull Request
## Issues
https://github.com/takapi327/real-estate-sales-contract-management-system/issues/16
## Summary
Slick-Refinedを導入
DAOの実装

## Note
newtypeでマッピングを行いたかったが、暗黙的な変換は非推奨であったため明示的に処理を行う。
UUIDもRefinedにしようかとも考えたが、一旦保留。
newtypeの実装で、`def v = value.value`が気持ち悪いかつ、統一できないので、どうにかしたい